### PR TITLE
Pitch up override

### DIFF
--- a/src/cougars_control/src/coug_kinematics.cpp
+++ b/src/cougars_control/src/coug_kinematics.cpp
@@ -202,6 +202,7 @@ private:
   rclcpp::Subscription<frost_interfaces::msg::UCommand>::SharedPtr
       command_subscription_;
   rclcpp::Service<std_srvs::srv::SetBool>::SharedPtr arm_service_;
+  rclcpp::Service<std_srvs::srv::SetBool>::SharedPtr surface_service_;
 };
 
 int main(int argc, char *argv[]) {

--- a/src/cougars_control/src/coug_kinematics.cpp
+++ b/src/cougars_control/src/coug_kinematics.cpp
@@ -89,6 +89,17 @@ public:
             std::bind(&CougKinematics::arm_thruster, this, std::placeholders::_1, std::placeholders::_2));
 
     /**
+     * @brief Kinematics pitch up override service.
+     *
+     * This service recieves requests on the "/surface" service.
+     * It uses the std_srvs/srv/SetBool service type.
+     * False will allow for normal control, true will override any commands and pitch vehicle up
+     */
+    surface_service_ = this->create_service<std_srvs::srv::SetBool>(
+            "surface", 
+            std::bind(&CougKinematics::surface, this, std::placeholders::_1, std::placeholders::_2));
+
+    /**
      * @brief Kinematics command publisher.
      *
      * This publisher publishes the commands to the "kinematics/command" topic.
@@ -125,15 +136,22 @@ private:
 
     auto command = frost_interfaces::msg::UCommand();
     command.header.stamp = msg.header.stamp;
-    command.fin[0] =
-        msg.fin[0] + this->get_parameter("top_fin_offset").as_double() +
-        this->get_parameter("trim_ratio").as_double() * msg.thruster;
-    command.fin[1] = -1 *
-        msg.fin[1] + this->get_parameter("right_fin_offset").as_double() +
-        this->get_parameter("trim_ratio").as_double() * msg.thruster;
-    command.fin[2] =
-        msg.fin[2] + this->get_parameter("left_fin_offset").as_double() +
-        this->get_parameter("trim_ratio").as_double() * msg.thruster;
+    
+    if(!surface_override_){
+      command.fin[0] =
+          msg.fin[0] + this->get_parameter("top_fin_offset").as_double() +
+          this->get_parameter("trim_ratio").as_double() * msg.thruster;
+      command.fin[1] = -1 *
+          msg.fin[1] + this->get_parameter("right_fin_offset").as_double() +
+          this->get_parameter("trim_ratio").as_double() * msg.thruster;
+      command.fin[2] =
+          msg.fin[2] + this->get_parameter("left_fin_offset").as_double() +
+          this->get_parameter("trim_ratio").as_double() * msg.thruster;
+    } else {
+      command.fin[0] = 0;
+      command.fin[1] = -25;  // TODO: make sure this pitches the vehicle up!!
+      command.fin[2] = 25;
+    }
 
     if (this->get_parameter("demo_mode").as_bool()) {
       command.thruster = 0;
@@ -156,7 +174,27 @@ private:
     RCLCPP_INFO(this->get_logger(), response->message.c_str());
   }
 
+  void surface(const std::shared_ptr<std_srvs::srv::SetBool::Request> request,
+                        std::shared_ptr<std_srvs::srv::SetBool::Response> response)
+  {
+    // Set the boolean to the requested value
+    surface_override_ = request->data;
+    response->success = true;
+    response->message = surface_override_ ? "Fin Override!" : "Fin actuation!";
+    RCLCPP_INFO(this->get_logger(), response->message.c_str());
+
+    //Publish the fins up command
+    auto command = frost_interfaces::msg::UCommand();
+
+    command.fin[0] = 0;
+    command.fin[1] = -25;  // TODO: make sure this pitches the vehicle up!!
+    command.fin[2] = 25;
+
+    command_publisher_->publish(command);    
+  }
+
   bool arm_thruster_ = false;
+  bool surface_override_ = false;
 
   // ROS objects
   rclcpp::Publisher<frost_interfaces::msg::UCommand>::SharedPtr


### PR DESCRIPTION
### Description: 
- Service available on coug kinematics that allows the vehicle to turn the fins to pitch up.
- The thruster will stay on if the controller is still giving commands and thruster is armed
- The thruster will turn off if thruster is disarmed 
- This node runs correctly even if the controller node dies

### Checklist:
- [x] Code builds in container.
- [x] Code runs in the container and on a vehicle.
- [x] I have updated the documentation as needed.
- [x] I have performed a self-review of my code.
- [x] I have resolved any merge conflicts before submission.

### Tests:
- [x] Bench Test
- [x] Bucket Test / Tank Test
- [ ] Tested outside
- [ ] Tested in the field

### Required Changes before merge:
- None

### Additional work possible:
Make the configuration of the negatives of the fins local parameters. 
This code will probably not work across vehicles

### Additional Notes:
I Need to update the new teensy firmware to have the timeout after 2 seconds of not receiving a command

### Related Issues:
None
