### PR TITLE
added cougars coms to manual_launch.py

### DIFF
--- a/src/cougars_control/launch/manual_launch.py
+++ b/src/cougars_control/launch/manual_launch.py
@@ -76,6 +76,13 @@ def generate_launch_description():
             parameters=[param_file],
             namespace=namespace,
         ),
+        launch_ros.actions.Node(
+            package='cougars_coms',
+            executable='cougars_coms',
+            parameters=[param_file],
+            namespace=namespace,
+            output=output,
+        ),
         # Start the EmergencyStop checks
         # launch_ros.actions.Node(
         #     package='cougars_control',

--- a/src/cougars_control/launch/manual_launch.py
+++ b/src/cougars_control/launch/manual_launch.py
@@ -95,13 +95,6 @@ def generate_launch_description():
             namespace=namespace,
             output=output,
         ),
-        launch_ros.actions.Node(
-            package='cougars_coms',
-            executable='cougars_coms',
-            parameters=[param_file],
-            namespace=namespace,
-            output=output,
-        ),
         # Start the EmergencyStop checks
         # launch_ros.actions.Node(
         #     package='cougars_control',

--- a/src/cougars_control/launch/moos_launch.py
+++ b/src/cougars_control/launch/moos_launch.py
@@ -109,13 +109,6 @@ def generate_launch_description():
             namespace=namespace,
             output=output,
         ),
-        launch_ros.actions.Node(
-            package='cougars_coms',
-            executable='cougars_coms',
-            parameters=[param_file],
-            namespace=namespace,
-            output=output,
-        ),
         # Start the EmergencyStop checks
         # launch_ros.actions.Node(
         #     package='cougars_control',

--- a/src/cougars_localization/launch/converters_launch.py
+++ b/src/cougars_localization/launch/converters_launch.py
@@ -51,7 +51,12 @@ def generate_launch_description():
 
     launch_actions.extend([
         # Start the data conversion nodes
-        
+        launch_ros.actions.Node(
+            package='cougars_coms',
+            executable='cougars_coms',
+            parameters=[param_file],
+            namespace=namespace
+        ),
         launch_ros.actions.Node(
             package='cougars_localization',
             executable='seatrac_ahrs_convertor',

--- a/src/seatrac/src/modem_ros_node.cpp
+++ b/src/seatrac/src/modem_ros_node.cpp
@@ -377,7 +377,7 @@ private:
   bool beacon_connected = false;
 
   std::string get_serial_port() {
-    this->declare_parameter("seatrac_serial_port", "/dev/ttyUSB0");
+    this->declare_parameter("seatrac_serial_port", "/dev/frost/rs232_connector_seatrac");
     return this->get_parameter("seatrac_serial_port").as_string();
   }
 


### PR DESCRIPTION
### Description: 
- added cougars_coms node to manual_launch.py.  cougars_coms currently handles the emergency stop thruster command using the acoustic modem, and will be expanded to include all high level modem commands
- also changed the default seatrac_serial_port from '/dev/ttyUSB0' to '/dev/frost/rs232_connector_seatrac' to reflect the added seatrac udev rule. This feature was tested on coug2 and works as expected.

### Checklist:
- [x] Code builds in container.
- [x] Code runs in the container and on a vehicle.
- [ ] I have updated the documentation as needed.
- [x] I have performed a self-review of my code.
- [x] I have resolved any merge conflicts before submission.

### Tests:
- [ ] Bench Test
- [x] Bucket Test / Tank Test
- [ ] Tested outside
- [ ] Tested in the field

### Required Changes before merge:
none

### Additional work possible:
Status messages and vehicle status update schedule
