### PR TITLE
Modem send queue

### DIFF
--- a/src/seatrac/src/modem_pinger.cpp
+++ b/src/seatrac/src/modem_pinger.cpp
@@ -49,7 +49,7 @@ public:
          * then this would be the time between pings from Coug 1 and Coug 2.
          * WARNING: ping_delay_seconds should be the same for all vehicles.
          */
-        this->declare_parameter<int>("ping_delay_seconds", 5);
+        this->declare_parameter<int>("ping_delay_seconds", 0);
 
         /**
          * @param number_of_vehicles
@@ -156,7 +156,7 @@ private:
             std::this_thread::sleep_for(std::chrono::seconds(sleep_time));
 
             send_ping();
-            std::this_thread::sleep_for(2s);
+            std::this_thread::sleep_for(100ms);
         }
     }
 

--- a/src/seatrac/src/modem_ros_node.cpp
+++ b/src/seatrac/src/modem_ros_node.cpp
@@ -428,7 +428,7 @@ private:
     if(modem_send_queue_.size()>=QUEUE_WARN_SIZE)
       RCLCPP_WARN(this->get_logger(), "Acoustic Message Queue size of %d is larger than %d", 
                     static_cast<int>(modem_send_queue_.size()), QUEUE_WARN_SIZE);
-    send_acoustic_message(rosmsg);
+    if(modem_send_queue_.size()==1) send_acoustic_message(rosmsg); 
   }
 
   //copies the current timestamp to 
@@ -547,12 +547,11 @@ private:
 
       case CST_XCVR_BUSY: {
         std::ostringstream ss;
-        ss << "Seatrac Busy. "<<msg_id<<" message to "<<target_id
-           << " added to queue. Queue size: "<<modem_send_queue_.size();
+        ss << "Seatrac Busy. Could not send "<<msg_id<<" message to "
+           <<target_id<< ". Queue size: "<<modem_send_queue_.size();
         RCLCPP_INFO(this->get_logger(), ss.str().c_str());
-        std::this_thread::sleep_for(std::chrono::milliseconds(500));
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
         std::lock_guard<std::mutex> lock(modem_send_queue_mutex_);
-        send_acoustic_message(modem_send_queue_.front());
       } break;
 
       case CST_CMD_PARAM_INVALID: {
@@ -580,6 +579,9 @@ private:
                       static_cast<int>(modem_send_queue_.size()));
       } break;
     }
+  
+    if(modem_send_queue_.size()>=1) send_acoustic_message(modem_send_queue_.front());
+
   }
 
 

--- a/src/seatrac_interfaces/msg/ModemSend.msg
+++ b/src/seatrac_interfaces/msg/ModemSend.msg
@@ -19,6 +19,11 @@ uint8 msg_type         # AMSGTYPE_E. Specifies how the remote beacon should resp
 uint8 packet_len       # optional packet length for data send commands (0 to 30)
 uint8[30] packet_data  # optional packet data array for data send commands
 
+bool insert_timestamp  # for some applications, it may be usefull to include a timestamp with the message taken at
+                       # at the last possible moment before it sends. If true, the timestamp will be written as an 
+                       # unsigned 4 byte/32 bit integer to the 2nd - 5th bytes in packet_data.
+                       # (the first byte is reserved for the message type)
+
 uint8 nav_query_flags  # NAV_QUERY_T. Bit mask indicating which fields the NAV response should return.
                        # Used only with the NAV protocol
 


### PR DESCRIPTION
### Description: 
- There is a risk of messages not being sent if the modem is busy listening to or sending another message.  This update implements a queue to save messages for later.
- Added an option to include a 4 byte timestamp in any sent modem message.  The timestamp will be copied to the 2nd through 5th bytes in the payload if included.
- Added a ros parameter logging_verbosity that lets the user modify the number of messages this node prints to the terminal.
- modem_ros_node similarly modified in cougars-base-station. See related pull request.


### Checklist:
- [x] Code builds in container.
- [ ] Code runs in the container and on a vehicle.  << Code runs in container.  Have not tested on vehicle.  There should be no difference though.
- [x] I have updated the documentation as needed.
- [x] I have performed a self-review of my code.
- [x] I have resolved any merge conflicts before submission.
- [ ] Node Parameters updated and working on Template and Vehicles (if applicable)

### Tests:

- [x] Tested on modem in bucket from Linux computer in container.  There should be no differences between running in the container on my computer and running on the actual vehicle.
- [ ] Bench Test
- [ ] Bucket Test / Tank Test
- [ ] Tested outside
- [ ] Tested in the field

### Required Changes before merge:
- If there are items here then mark as draft pull request

### Additional work possible:
Any changes that could be made in the future to improve the code

### Additional Notes:
Add any additional notes or comments here.

### Related Issues:
Closes # (issue)
