### PR TITLE
Modem queue bug fix

### DIFF
--- a/src/seatrac/src/modem_ros_node.cpp
+++ b/src/seatrac/src/modem_ros_node.cpp
@@ -178,7 +178,7 @@ public:
         report = data;
         msg.command_status_code = report.status;
         msg.target_id = report.beaconId;
-        verify_modem_send(std::make_shared<seatrac_interfaces::msg::ModemCmdUpdate>(msg));
+        handle_send_update(std::make_shared<seatrac_interfaces::msg::ModemCmdUpdate>(msg));
         cmd_update_pub_->publish(msg);
 
       } break;
@@ -230,7 +230,7 @@ public:
         report = data;
         msg.command_status_code = report.status;
         msg.target_id = report.beaconId;
-        verify_modem_send(std::make_shared<seatrac_interfaces::msg::ModemCmdUpdate>(msg));
+        handle_send_update(std::make_shared<seatrac_interfaces::msg::ModemCmdUpdate>(msg));
         cmd_update_pub_->publish(msg);
       } break;
 
@@ -280,7 +280,7 @@ public:
         report = data;
         msg.command_status_code = report.statusCode;
         msg.target_id = report.target;
-        verify_modem_send(std::make_shared<seatrac_interfaces::msg::ModemCmdUpdate>(msg));
+        handle_send_update(std::make_shared<seatrac_interfaces::msg::ModemCmdUpdate>(msg));
         cmd_update_pub_->publish(msg);
       } break;
 
@@ -347,7 +347,7 @@ public:
         report = data;
         msg.command_status_code = report.status;
         msg.target_id = report.beaconId;
-        verify_modem_send(std::make_shared<seatrac_interfaces::msg::ModemCmdUpdate>(msg));
+        handle_send_update(std::make_shared<seatrac_interfaces::msg::ModemCmdUpdate>(msg));
         cmd_update_pub_->publish(msg);
       } break;
 
@@ -490,7 +490,7 @@ private:
       }
       send_acoustic_message(send_queue.front());
       time_last_sent = this->get_clock()->now();
-      send_delay_ticker = 5; //400ms for 4 ticks at 10Hz (subtracting this one)
+      send_delay_ticker = 5; //400ms for 4 ticks at 10Hz (subtracting this tick)
     }
   }
   void send_acoustic_message(const seatrac_interfaces::msg::ModemSend::SharedPtr rosmsg) {
@@ -539,7 +539,7 @@ private:
     }
   }
 
-  inline void verify_modem_send(seatrac_interfaces::msg::ModemCmdUpdate::SharedPtr rosmsg) {
+  inline void handle_send_update(seatrac_interfaces::msg::ModemCmdUpdate::SharedPtr rosmsg) {
     std::lock_guard<std::mutex> lock(send_mutex);
     switch(rosmsg->command_status_code) {
       case CST_OK: {
@@ -576,7 +576,6 @@ private:
           RCLCPP_INFO(this->get_logger(), ss.str().c_str());
         }
       } break;
-
       default: {
         send_queue.pop();
         if(logging_verbosity>=1) {
@@ -586,6 +585,8 @@ private:
         }
       } break;
     }
+    rosmsg->time_sent = time_last_sent;
+    rosmsg->queue_size = (uint8_t)send_queue.size();
   }
 
 };

--- a/src/seatrac_interfaces/msg/ModemCmdUpdate.msg
+++ b/src/seatrac_interfaces/msg/ModemCmdUpdate.msg
@@ -14,8 +14,8 @@ uint8 command_status_code # CST_E. Indicates the status of the
 uint8 target_id   # BID_E. For error reports from acoustic transmissions, the target_id is the id of the remote beacon.
 
 uint8 queue_size  # The size of the queue (implemented in modem_ros_node) of messages waiting to be
-                  # waiting to be over the modem
+                  # waiting to be over the modem (after this message was processed)
 
-# The header stores the time this message was recieved.
-# This timestamp is the time the message was requested from the beacon.
+# header.stamp is the time the response was processed.
+# time_sent is the time the acoustic signal was requested from the beacon.
 builtin_interfaces/Time time_sent

--- a/src/seatrac_interfaces/msg/ModemCmdUpdate.msg
+++ b/src/seatrac_interfaces/msg/ModemCmdUpdate.msg
@@ -12,3 +12,10 @@ uint8 msg_id            # CID_E - Command Identification Code. Indicates the typ
         # Reports that include a command status code usually do not include any other fields besides msg_id and local_beacon_id
 uint8 command_status_code # CST_E. Indicates the status of the 
 uint8 target_id   # BID_E. For error reports from acoustic transmissions, the target_id is the id of the remote beacon.
+
+uint8 queue_size  # The size of the queue (implemented in modem_ros_node) of messages waiting to be
+                  # waiting to be over the modem
+
+# The header stores the time this message was recieved.
+# This timestamp is the time the message was requested from the beacon.
+builtin_interfaces/Time time_sent

--- a/src/seatrac_interfaces/msg/ModemSend.msg
+++ b/src/seatrac_interfaces/msg/ModemSend.msg
@@ -19,11 +19,6 @@ uint8 msg_type         # AMSGTYPE_E. Specifies how the remote beacon should resp
 uint8 packet_len       # optional packet length for data send commands (0 to 30)
 uint8[30] packet_data  # optional packet data array for data send commands
 
-bool insert_timestamp  # for some applications, it may be usefull to include a timestamp with the message taken at
-                       # at the last possible moment before it sends. If true, the timestamp will be written as an 
-                       # unsigned 4 byte/32 bit integer to the 2nd - 5th bytes in packet_data.
-                       # (the first byte is reserved for the message type)
-
 uint8 nav_query_flags  # NAV_QUERY_T. Bit mask indicating which fields the NAV response should return.
                        # Used only with the NAV protocol
 


### PR DESCRIPTION
### Description: 
Fixes a bug with the modem queue where the modem would stop sending messages if the queue got too big.
Also removes the "insert timestamp" feature (where the modem would add a timestamp to the payload of the acoustic message right before sending).
In it's place, adds an additional timestamp field (of the time the message was broadcast) and a queue size field to the ModemCmdUpdate ros message.

### Checklist:
- [X] Code builds in container.
- [X] Code runs in the container and on a vehicle.
- [X] I have updated the documentation as needed.
- [X] I have performed a self-review of my code.
- [X] I have resolved any merge conflicts before submission.
- [ ] Node Parameters updated and working on Template and Vehicles (if applicable)

### Tests:
- [ ] Bench Test
- [X] Bucket Test / Tank Test
- [ ] Tested outside
- [ ] Tested in the field

### Required Changes before merge:
Merge "Removes insert_timestamps" pull request in base station with this pull request

### Related Issues:
Closes "Base Station Kill Command fail" in cougars repo
